### PR TITLE
fix:misspelling

### DIFF
--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -147,7 +147,7 @@ class ToolParameter(BaseModel):
         FILES = "files"
 
         # deprecated, should not use.
-        SYSTEM_FILES = "systme-files"
+        SYSTEM_FILES = "system-files"
 
         def as_normal_type(self):
             if self in {


### PR DESCRIPTION
# Summary
This pull request includes a minor correction in the `ToolParameterType` class within the `api/core/tools/entities/tool_entities.py` file. The change corrects a typo in the `SYSTEM_FILES` value.

* [`api/core/tools/entities/tool_entities.py`](diffhunk://#diff-fb1dff33a649d5e47cdc9162860fb507336e7b47b10fa7bb06c565decf3c8c80L150-R150): Corrected the typo from "systme-files" to "system-files" in the `SYSTEM_FILES` value.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

