### PR TITLE
fix(workflow): enforce array-only filtering in List Operator; remove file children fallback and align child types.

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -42,6 +42,7 @@ import type { RAGPipelineVariable } from '@/models/pipeline'
 
 import {
   AGENT_OUTPUT_STRUCT,
+  FILE_STRUCT,
   HTTP_REQUEST_OUTPUT_STRUCT,
   KNOWLEDGE_RETRIEVAL_OUTPUT_STRUCT,
   LLM_OUTPUT_STRUCT,
@@ -138,6 +139,10 @@ export const varTypeToStructType = (type: VarType): Type => {
         [VarType.boolean]: Type.boolean,
         [VarType.object]: Type.object,
         [VarType.array]: Type.array,
+        [VarType.arrayString]: Type.array,
+        [VarType.arrayNumber]: Type.array,
+        [VarType.arrayObject]: Type.array,
+        [VarType.arrayFile]: Type.array,
       } as any
     )[type] || Type.string
   )
@@ -282,15 +287,6 @@ const findExceptVarInObject = (
           children: filteredObj.children,
         }
       })
-
-    if (isFile && Array.isArray(childrenResult)) {
-      if (childrenResult.length === 0) {
-        childrenResult = OUTPUT_FILE_SUB_VARIABLES.map(key => ({
-          variable: key,
-          type: key === 'size' ? VarType.number : VarType.string,
-        }))
-      }
-    }
   }
   else {
     childrenResult = []
@@ -586,17 +582,15 @@ const formatItem = (
             variable: outputKey,
             type:
               output.type === 'array'
-                ? (`Array[${
-                  output.items?.type
-                    ? output.items.type.slice(0, 1).toLocaleUpperCase()
-                        + output.items.type.slice(1)
-                    : 'Unknown'
+                ? (`Array[${output.items?.type
+                  ? output.items.type.slice(0, 1).toLocaleUpperCase()
+                  + output.items.type.slice(1)
+                  : 'Unknown'
                 }]` as VarType)
-                : (`${
-                  output.type
-                    ? output.type.slice(0, 1).toLocaleUpperCase()
-                        + output.type.slice(1)
-                    : 'Unknown'
+                : (`${output.type
+                  ? output.type.slice(0, 1).toLocaleUpperCase()
+                  + output.type.slice(1)
+                  : 'Unknown'
                 }` as VarType),
           })
         },
@@ -690,9 +684,10 @@ const formatItem = (
       const children = (() => {
         if (isFile) {
           return OUTPUT_FILE_SUB_VARIABLES.map((key) => {
+            const def = FILE_STRUCT.find(c => c.variable === key)
             return {
               variable: key,
-              type: key === 'size' ? VarType.number : VarType.string,
+              type: def?.type || VarType.string,
             }
           })
         }
@@ -714,9 +709,10 @@ const formatItem = (
         if (isFile) {
           return {
             children: OUTPUT_FILE_SUB_VARIABLES.map((key) => {
+              const def = FILE_STRUCT.find(c => c.variable === key)
               return {
                 variable: key,
-                type: key === 'size' ? VarType.number : VarType.string,
+                type: def?.type || VarType.string,
               }
             }),
           }

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -18,7 +18,6 @@ import { Type } from '../../../llm/types'
 import PickerStructurePanel from '@/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker'
 import { isSpecialVar, varTypeToStructType } from './utils'
 import type { Field } from '@/app/components/workflow/nodes/llm/types'
-import { FILE_STRUCT } from '@/app/components/workflow/constants'
 import { noop } from 'lodash-es'
 import { CodeAssistant, MagicEdit } from '@/app/components/base/icons/src/vender/line/general'
 import ManageInputField from './manage-input-field'
@@ -106,8 +105,9 @@ const Item: FC<ItemProps> = ({
 
   const objStructuredOutput: StructuredOutput | null = useMemo(() => {
     if (!isObj) return null
-    const properties: Record<string, Field> = {};
-    (isFile ? FILE_STRUCT : (itemData.children as Var[])).forEach((c) => {
+    const properties: Record<string, Field> = {}
+    const childrenVars = (itemData.children as Var[]) || []
+    childrenVars.forEach((c) => {
       properties[c.variable] = {
         type: varTypeToStructType(c.type),
       }
@@ -120,7 +120,7 @@ const Item: FC<ItemProps> = ({
         additionalProperties: false,
       },
     }
-  }, [isFile, isObj, itemData.children])
+  }, [isObj, itemData.children])
 
   const structuredOutput = (() => {
     if (isStructureOutput)
@@ -448,4 +448,5 @@ const VarReferenceVars: FC<Props> = ({
     </>
   )
 }
+
 export default React.memo(VarReferenceVars)

--- a/web/app/components/workflow/nodes/list-operator/panel.tsx
+++ b/web/app/components/workflow/nodes/list-operator/panel.tsx
@@ -55,6 +55,7 @@ const Panel: FC<NodePanelProps<ListFilterNodeType>> = ({
             value={inputs.variable || []}
             onChange={handleVarChanges}
             filterVar={filterVar}
+            isSupportFileVar={false}
             typePlaceHolder='Array'
           />
         </Field>


### PR DESCRIPTION
- Remove fallback in findExceptVarInObject that repopulates default file sub-variables when children are filtered out, preventing File and non-matching children from leaking into the picker.
- Make VarReferenceVars render object/file children from filtered itemData.children, not from FILE_STRUCT, eliminating phase mismatch.
- Align file sub-variable types in filtering and rendering using FILE_STRUCT as the single source of truth.
- Disallow selecting File root in List Operator (isSupportFileVar={false}); array children remain selectable.
- Map VarType.array* → Type.array in varTypeToStructType to represent arrays correctly.
- Remove debug console.info.
- Affected files:
  - app/components/workflow/nodes/_base/components/variable/utils.ts
  - app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
  - app/components/workflow/nodes/list-operator/panel.tsx

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
